### PR TITLE
feat: removed cjs wrapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,14 +11,14 @@
     "type": "opencollective",
     "url": "https://opencollective.com/webpack"
   },
-  "main": "dist/cjs.js",
-  "types": "types/cjs.d.ts",
+  "main": "dist/index.js",
+  "types": "types/index.d.ts",
   "engines": {
     "node": ">= 12.13.0"
   },
   "scripts": {
     "start": "npm run build -- -w",
-    "clean": "del-cli dist",
+    "clean": "del-cli dist types",
     "prebuild": "npm run clean",
     "build:types": "tsc --declaration --emitDeclarationOnly --outDir types && prettier \"types/**/*.ts\" --write",
     "build:code": "cross-env NODE_ENV=production babel src -d dist --copy-files",

--- a/src/cjs.js
+++ b/src/cjs.js
@@ -1,1 +1,0 @@
-module.exports = require("./index").default;

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
-import { validate } from "schema-utils";
+const { validate } = require("schema-utils");
 
-import schema from "./options.json";
-import { minify as minifyFn } from "./minify";
+const schema = require("./options.json");
+const { minify } = require("./minify");
 
 /** @typedef {import("schema-utils/declarations/validate").Schema} Schema */
 /** @typedef {import("webpack").Compiler} Compiler */
@@ -156,7 +156,7 @@ class JsonMinimizerPlugin {
             };
 
             try {
-              output = await minifyFn(options);
+              output = await minify(options);
             } catch (error) {
               compilation.errors.push(
                 /** @type {WebpackError} */ (
@@ -220,4 +220,4 @@ class JsonMinimizerPlugin {
   }
 }
 
-export default JsonMinimizerPlugin;
+module.exports = JsonMinimizerPlugin;

--- a/src/minify.js
+++ b/src/minify.js
@@ -25,4 +25,4 @@ const minify = async (options) => {
   return { code: result };
 };
 
-module.exports.minify = minify;
+module.exports = { minify };

--- a/test/cjs.test.js
+++ b/test/cjs.test.js
@@ -1,8 +1,0 @@
-import src from "../src";
-import cjs from "../src/cjs";
-
-describe("CJS", () => {
-  it("should export loader", () => {
-    expect(cjs).toEqual(src);
-  });
-});

--- a/types/cjs.d.ts
+++ b/types/cjs.d.ts
@@ -1,2 +1,0 @@
-declare const _exports: typeof import("./index").default;
-export = _exports;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,31 +1,4 @@
-export default JsonMinimizerPlugin;
-export type Schema = import("schema-utils/declarations/validate").Schema;
-export type Compiler = import("webpack").Compiler;
-export type Compilation = import("webpack").Compilation;
-export type Asset = import("webpack").Asset;
-export type WebpackError = import("webpack").WebpackError;
-export type Rule = RegExp | string;
-export type Rules = Rule[] | Rule;
-export type JSONOptions = {
-  replacer?:
-    | ((this: any, key: string, value: any) => any | (number | string)[] | null)
-    | undefined;
-  space?: string | number | undefined;
-};
-export type BasePluginOptions = {
-  test?: Rules | undefined;
-  include?: Rules | undefined;
-  exclude?: Rules | undefined;
-  minimizerOptions?: JSONOptions | undefined;
-};
-export type MinimizedResult = {
-  code: string;
-};
-export type InternalOptions = {
-  input: string;
-  minimizerOptions?: JSONOptions | undefined;
-};
-export type InternalPluginOptions = BasePluginOptions;
+export = JsonMinimizerPlugin;
 /** @typedef {import("schema-utils/declarations/validate").Schema} Schema */
 /** @typedef {import("webpack").Compiler} Compiler */
 /** @typedef {import("webpack").Compilation} Compilation */
@@ -59,13 +32,12 @@ export type InternalPluginOptions = BasePluginOptions;
  */
 declare class JsonMinimizerPlugin {
   /**
-   * @private
    * @param {any} error
    * @param {string} file
    * @param {string} context
    * @returns {Error}
    */
-  private static buildError;
+  static buildError(error: any, file: string, context: string): Error;
   /**
    * @param {BasePluginOptions} [options]
    */
@@ -89,3 +61,46 @@ declare class JsonMinimizerPlugin {
    */
   apply(compiler: Compiler): void;
 }
+declare namespace JsonMinimizerPlugin {
+  export {
+    Schema,
+    Compiler,
+    Compilation,
+    Asset,
+    WebpackError,
+    Rule,
+    Rules,
+    JSONOptions,
+    BasePluginOptions,
+    MinimizedResult,
+    InternalOptions,
+    InternalPluginOptions,
+  };
+}
+type Compiler = import("webpack").Compiler;
+type BasePluginOptions = {
+  test?: Rules | undefined;
+  include?: Rules | undefined;
+  exclude?: Rules | undefined;
+  minimizerOptions?: JSONOptions | undefined;
+};
+type Schema = import("schema-utils/declarations/validate").Schema;
+type Compilation = import("webpack").Compilation;
+type Asset = import("webpack").Asset;
+type WebpackError = import("webpack").WebpackError;
+type Rule = RegExp | string;
+type Rules = Rule[] | Rule;
+type JSONOptions = {
+  replacer?:
+    | ((this: any, key: string, value: any) => any | (number | string)[] | null)
+    | undefined;
+  space?: string | number | undefined;
+};
+type MinimizedResult = {
+  code: string;
+};
+type InternalOptions = {
+  input: string;
+  minimizerOptions?: JSONOptions | undefined;
+};
+type InternalPluginOptions = BasePluginOptions;


### PR DESCRIPTION
<!--
  HOLY CRAP a Pull Request. We ❤️ those!

  If you remove or skip this template, you'll make the 🐼 sad and the mighty god
  of Github will appear and pile-drive the close button from a great height
  while making animal noises.

  Please place an x (no spaces!) in all [ ] that apply
-->

This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [x] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [x] **metadata update**

### Motivation / Use-Case

removed cjs wrapper and generated types in commonjs format (`export =` and `namespaces` used in types), now you can directly use exported types

### Breaking Changes

Potentially yes, but now we use invalid format our types

### Additional Info

No